### PR TITLE
ci: add GitHub Actions workflow to run Zig tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Zig
+        run: |
+          wget https://ziglang.org/download/0.14.1/zig-x86_64-linux-0.14.1.tar.xz
+          tar xf zig-x86_64-linux-0.14.1.tar.xz
+          echo "$PWD/zig-x86_64-linux-0.14.1" >> $GITHUB_PATH
+
+      - name: Run tests
+        run: zig test src/root.zig

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Install Zig
-        run: |
-          wget https://ziglang.org/download/0.14.1/zig-x86_64-linux-0.14.1.tar.xz
-          tar xf zig-x86_64-linux-0.14.1.tar.xz
-          echo "$PWD/zig-x86_64-linux-0.14.1" >> $GITHUB_PATH
+      - name: Setup Zig
+        uses: korandoru/setup-zig@v1
+        with:
+          zig-version: 0.14.1
 
       - name: Run tests
         run: zig test src/root.zig


### PR DESCRIPTION
This PR introduces a basic CI setup using GitHub Actions for the project.
- Runs on push and pull request events to the repository
- Downloads and installs Zig 0.14.1 on an Ubuntu runner
- Executes the existing Zig tests via `zig test src/root.zig`